### PR TITLE
hooks: Fix path of uncrustify config file

### DIFF
--- a/scripts/helpers/indent-helper.sh
+++ b/scripts/helpers/indent-helper.sh
@@ -10,7 +10,7 @@
 #
 
 SCRIPT=$(realpath $0)
-SCRIPT_DIR=$(dirname "$SCRIPT")
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 check_command() {
   local program=$1
@@ -104,7 +104,7 @@ INDENT_PARAMETERS="--braces-on-if-line \
   --indent-level2 \
   --leave-preprocessor-space"
 
-UNCRUSTIFY_CONFIG_FILE="$SCRIPT_DIR/data/uncrustify.cfg"
+UNCRUSTIFY_CONFIG_FILE="$ROOT_DIR/scripts/data/uncrustify.cfg"
 
 run_indent() {
   local nf=$1
@@ -134,3 +134,4 @@ check_coding_style() {
     run_uncrustify $nf $newfile
   fi
 }
+


### PR DESCRIPTION
Before this commit, if the pre-commit hook was located at
.git/hooks/pre-commit it would try to search for the uncristify
config file at .git/hooks/data/uncrustify.cfg

Closes #3