### PR TITLE
hooks: pre-commit: Prevent to parse .cpp files as .c files

### DIFF
--- a/hooks/pre-commit.hook
+++ b/hooks/pre-commit.hook
@@ -16,10 +16,16 @@ source "$ROOT_DIR/scripts/helpers/indent-helper.sh" $@
 
 echo "--Checking style--"
 for file in `git diff-index --cached --name-only HEAD --diff-filter=ACMR| grep "\.c$\|\.cpp$"` ; do
+    extension="${file##*.}"
     # nf is the temporary checkout. This makes sure we check against the
     # revision in the index (and not the checked out version).
+    # Also, we append the extension, so uncrustify does not parse .cpp files as .c files.
     nf=`git checkout-index --temp ${file} | cut -f 1`
-    newfile=`mktemp /tmp/${nf}.XXXXXX` || exit 1
+    tmp_nf="$nf.$extension"
+    mv $nf $tmp_nf
+
+    nf=$tmp_nf
+    newfile=`mktemp /tmp/${nf}.XXXXXX.$extension` || exit 1
 
     check_coding_style $nf $newfile
     diff -u -p "${nf}" "${newfile}"


### PR DESCRIPTION
In the pre-commit hook, a temporary file of the current staged
revision is created. Because the resulting filename is a "random"
string without an extension, uncrustify may think that the file is
written in other programming language instead of the one it is
actually written in. To prevent that, the file extension is added
to this temporary name.

Closes #4