### PR TITLE
gst-libs: object: Add structures that store info about objects

### DIFF
--- a/gst-libs/gst/cv/meson.build
+++ b/gst-libs/gst/cv/meson.build
@@ -1,13 +1,23 @@
 cv_sources = [
   'gstcvobjectdetect.cpp',
   'dupscalemeta.cpp',
-  'utils.c'
+  'utils.c',
+  'object/info/objectinfo.c',
+  'object/info/objectinfomap.c',
+  'object/info/objectinfomapcache.c',
+  'object/info/objectinfomapmeta.c',
+  'object/info/objectinfomapcachemeta.c',
 ]
 
 cv_headers = [
   'gstcvobjectdetect.h',
   'dupscalemeta.h',
-  'utils.h'
+  'utils.h',
+  'object/info/objectinfo.h',
+  'object/info/objectinfomap.h',
+  'object/info/objectinfomapcache.h',
+  'object/info/objectinfomapmeta.h',
+  'object/info/objectinfomapcachemeta.h',
 ]
 
 if opencv_dep.found() and graphene_dep.found()
@@ -20,6 +30,7 @@ if opencv_dep.found() and graphene_dep.found()
     install : true,
     dependencies : [
       gio_dep,
+      gst_dep,
       gstbase_dep,
       graphene_dep,
       opencv_dep
@@ -28,7 +39,7 @@ if opencv_dep.found() and graphene_dep.found()
 
   gstcv_dep = declare_dependency(link_with: gstcv,
     include_directories : [libsinc],
-    dependencies : [opencv_dep, gio_dep])
+    dependencies : [opencv_dep, gio_dep, gst_dep])
 
   install_headers(cv_headers, subdir : 'gstreamer-1.0/gst/cv')
 

--- a/gst-libs/gst/cv/object/info/objectinfo.c
+++ b/gst-libs/gst/cv/object/info/objectinfo.c
@@ -1,0 +1,92 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "objectinfo.h"
+
+GstCVObjectInfo *
+gst_cv_object_info_new (const GValue * value)
+{
+  GstCVObjectInfo *self;
+  g_return_val_if_fail (G_IS_VALUE (value), NULL);
+
+  /* new0 initializes the underlying GValue to 0 */
+  self = g_slice_new0 (GstCVObjectInfo);
+
+  g_value_init (&self->value, G_VALUE_TYPE (value));
+  g_value_copy (value, &self->value);
+  self->params = NULL;
+
+  return self;
+}
+
+GstCVObjectInfo *
+gst_cv_object_info_new_with_params (const GValue * value, GstStructure * params)
+{
+  GstCVObjectInfo *self;
+  g_return_val_if_fail (G_IS_VALUE (value), NULL);
+  g_return_val_if_fail (GST_IS_STRUCTURE (params), NULL);
+
+  self = gst_cv_object_info_new (value);
+  gst_cv_object_info_add_params (self, params);
+
+  return self;
+}
+
+void
+gst_cv_object_info_add_params (GstCVObjectInfo * self, GstStructure * params)
+{
+  g_return_if_fail (self->params == NULL);
+  self->params = params;
+}
+
+GstStructure *
+gst_cv_object_info_get_params (GstCVObjectInfo * self)
+{
+  return self->params;
+}
+
+const GValue *
+gst_cv_object_info_get_value (GstCVObjectInfo * self)
+{
+  return &self->value;
+}
+
+GstCVObjectInfo *
+gst_cv_object_info_copy (const GstCVObjectInfo * self)
+{
+  GstCVObjectInfo *copy;
+
+  if (self->params) {
+    copy = gst_cv_object_info_new_with_params (&self->value,
+        gst_structure_copy (self->params));
+  } else {
+    copy = gst_cv_object_info_new (&self->value);
+  }
+
+  return copy;
+}
+
+void
+gst_cv_object_info_free (GstCVObjectInfo * self)
+{
+  g_value_unset (&self->value);
+  if (self->params)
+    gst_structure_free (self->params);
+  g_slice_free (GstCVObjectInfo, self);
+}

--- a/gst-libs/gst/cv/object/info/objectinfo.h
+++ b/gst-libs/gst/cv/object/info/objectinfo.h
@@ -1,0 +1,66 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __CV_OBJECT_INFO_H__
+#define __CV_OBJECT_INFO_H__
+
+#include <glib.h>
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+#define GST_CV_OBJECT_INFO_SUB_KEY_ROI  "roi"
+
+typedef enum {
+  GST_CV_OBJECT_INFO_TAG_UNDEFINED,
+  GST_CV_OBJECT_INFO_TAG_ROI,
+  /* GST_CV_OBJECT_INFO_TAG_LANDMARKS */
+} GstCVObjectInfoTag;
+
+struct _GstCVObjectInfo {
+  GValue value;
+  GstStructure *params;
+};
+
+typedef struct _GstCVObjectInfo GstCVObjectInfo;
+
+
+GstCVObjectInfo * gst_cv_object_info_new             (const GValue * value);
+
+void              gst_cv_object_info_destroy         (GstCVObjectInfo * self);
+
+GstCVObjectInfo * gst_cv_object_info_new_with_params (const GValue * value,
+                                                      GstStructure * params);
+
+const GValue *    gst_cv_object_info_get_value       (GstCVObjectInfo * self);
+
+void              gst_cv_object_info_add_params      (GstCVObjectInfo * self,
+                                                      GstStructure *    params);
+
+GstStructure *    gst_cv_object_info_get_params      (GstCVObjectInfo * self);
+
+
+GstCVObjectInfo * gst_cv_object_info_copy            (const GstCVObjectInfo * self);
+
+void              gst_cv_object_info_free            (GstCVObjectInfo * self);
+
+G_END_DECLS
+
+#endif /* __CV_OBJECT_INFO_H__ */

--- a/gst-libs/gst/cv/object/info/objectinfomap.c
+++ b/gst-libs/gst/cv/object/info/objectinfomap.c
@@ -1,0 +1,288 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "objectinfomap.h"
+
+static void
+gst_cv_combine_hash (guint * seed, const guint * hash)
+{
+  *seed ^= *hash + 0x9e3779b9 + (*seed << 6) + (*seed >> 2);
+}
+
+static gboolean
+gst_cv_object_info_map_key_hash_foreach (GQuark field_id, const GValue * value,
+    guint * hash)
+{
+  guint field_hash;
+  guint value_hash;
+
+  /* Field hash. */
+  field_hash = g_str_hash (g_quark_to_string (field_id));
+
+  /* Value hash. */
+  switch (G_VALUE_TYPE (value)) {
+    case G_TYPE_INT:
+    {
+      gint int_value = g_value_get_int (value);
+      value_hash = g_direct_hash (GINT_TO_POINTER (int_value));
+
+      break;
+    }
+    case G_TYPE_INT64:
+    {
+      gint int_value = g_value_get_int (value);
+      value_hash = g_int64_hash (GINT_TO_POINTER (int_value));
+      break;
+    }
+    case G_TYPE_STRING:
+    {
+      const gchar *int_value = g_value_get_string (value);
+      value_hash = g_int64_hash (GINT_TO_POINTER (int_value));
+      break;
+    }
+    default:
+      g_assert_not_reached ();
+  }
+
+  gst_cv_combine_hash (hash, &field_hash);
+  gst_cv_combine_hash (hash, &value_hash);
+
+  return TRUE;
+}
+
+static guint
+gst_cv_object_info_map_key_hash (gconstpointer key)
+{
+  guint hash = 0;
+  GstStructure *st = GST_STRUCTURE (key);
+
+  gst_structure_foreach (st,
+      (GstStructureForeachFunc) gst_cv_object_info_map_key_hash_foreach, &hash);
+
+  return hash;
+}
+
+static gboolean
+gst_cv_object_info_key_equal (gconstpointer k1, gconstpointer k2)
+{
+  return gst_structure_is_equal (GST_STRUCTURE (k1), GST_STRUCTURE (k2));
+}
+
+static void
+gst_cv_object_info_key_free (gpointer k)
+{
+  gst_structure_free (GST_STRUCTURE (k));
+}
+
+static gboolean
+gst_cv_object_info_map_check_key_foreach_func (GQuark field_id,
+    const GValue * value, gpointer user_data)
+{
+  GType type = G_VALUE_TYPE (value);
+
+  return type == G_TYPE_STRING || type == G_TYPE_INT || type == G_TYPE_INT64;
+}
+
+gboolean
+gst_cv_object_info_map_check_key (GstStructure * key)
+{
+  return gst_structure_foreach (key,
+      (GstStructureForeachFunc) gst_cv_object_info_map_check_key_foreach_func,
+      NULL);
+}
+
+GstCVObjectInfoMap *
+gst_cv_object_info_map_new ()
+{
+  GHashTable *table;
+
+  table = g_hash_table_new_full (gst_cv_object_info_map_key_hash,
+      gst_cv_object_info_key_equal, gst_cv_object_info_key_free,
+      (GDestroyNotify) gst_cv_object_info_free);
+
+  return table;
+}
+
+void
+gst_cv_object_info_map_destroy (GstCVObjectInfoMap * self)
+{
+  g_hash_table_destroy (self);
+}
+
+static gboolean
+gst_cv_object_info_map_insert_with_check (GstCVObjectInfoMap * self,
+    GstStructure * key, GstCVObjectInfo * value, gboolean check)
+{
+  if (check) {
+    g_return_val_if_fail (G_IS_VALUE (value), FALSE);
+    g_return_val_if_fail (GST_IS_STRUCTURE (key), FALSE);
+    g_return_val_if_fail (gst_cv_object_info_map_check_key (key), FALSE);
+  }
+
+  return g_hash_table_insert (self, key, value);
+}
+
+gboolean
+gst_cv_object_info_map_insert (GstCVObjectInfoMap * self, GstStructure * key,
+    GstCVObjectInfo * value)
+{
+  return gst_cv_object_info_map_insert_with_check (self, key, value, TRUE);
+}
+
+GstCVObjectInfo *
+gst_cv_object_info_map_lookup (GstCVObjectInfoMap * self,
+    const GstStructure * key)
+{
+  return g_hash_table_lookup (self, key);
+}
+
+void
+gst_cv_object_info_map_iter_init (GstCVObjectInfoMapIter * iter,
+    GstCVObjectInfoMap * map)
+{
+  g_hash_table_iter_init (&iter->iter, map);
+  iter->sub_key = NULL;
+}
+
+gboolean
+gst_cv_object_info_map_iter_next (GstCVObjectInfoMapIter * iter,
+    GstStructure ** key, GstCVObjectInfo ** value)
+{
+  return g_hash_table_iter_next (&iter->iter, (gpointer *) key,
+      (gpointer *) value);
+}
+
+void
+gst_cv_object_info_map_iter_init_with_sub_key (GstCVObjectInfoMapIter * iter,
+    GstCVObjectInfoMap * map, GstStructure * sub_key)
+{
+  g_hash_table_iter_init (&iter->iter, map);
+  iter->sub_key = sub_key;
+}
+
+GstCVObjectInfoMap *
+gst_cv_object_info_map_copy (GstCVObjectInfoMap * self)
+{
+  GstCVObjectInfoMap *copy;
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  copy = gst_cv_object_info_map_new ();
+
+  gst_cv_object_info_map_iter_init (&iter, self);
+  while (gst_cv_object_info_map_iter_next (&iter, &key, &value)) {
+    gst_cv_object_info_map_insert_with_check (copy,
+        gst_structure_copy (key), gst_cv_object_info_copy (value), FALSE);
+  }
+
+  return copy;
+}
+
+GstCVObjectInfoMap *
+gst_cv_object_info_map_copy_with_sub_key (GstCVObjectInfoMap * self,
+    GstStructure * sub_key)
+{
+  GstCVObjectInfoMap *copy;
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  copy = gst_cv_object_info_map_new ();
+
+  gst_cv_object_info_map_iter_init_with_sub_key (&iter, self, sub_key);
+  while (gst_cv_object_info_map_iter_next_with_sub_key (&iter, &key, &value)) {
+    gst_cv_object_info_map_insert_with_check (copy,
+        gst_structure_copy (key), gst_cv_object_info_copy (value), FALSE);
+  }
+
+  return copy;
+}
+
+gboolean
+gst_cv_object_info_map_iter_next_with_sub_key (GstCVObjectInfoMapIter * iter,
+    GstStructure ** key, GstCVObjectInfo ** value)
+{
+  g_return_val_if_fail (iter->sub_key != NULL, FALSE);
+
+  while (gst_cv_object_info_map_iter_next (iter, key, value)) {
+    if (gst_structure_is_subset (GST_STRUCTURE (*key), iter->sub_key))
+      return TRUE;
+
+    *key = NULL;
+    *value = NULL;
+  };
+  return FALSE;
+}
+
+void
+gst_cv_object_info_map_foreach (GstCVObjectInfoMap * self,
+    GstCVObjectInfoMapFunc foreach_func, gpointer user_data)
+{
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  gst_cv_object_info_map_iter_init (&iter, self);
+  while (gst_cv_object_info_map_iter_next (&iter, &key, &value))
+    foreach_func (key, value, user_data);
+}
+
+void
+gst_cv_object_info_map_foreach_with_sub_key (GstCVObjectInfoMap * self,
+    GstStructure * sub_key, GstCVObjectInfoMapFunc func, gpointer user_data)
+{
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  gst_cv_object_info_map_iter_init (&iter, self);
+  while (gst_cv_object_info_map_iter_next (&iter, &key, &value)) {
+    if (!gst_structure_is_subset (iter.sub_key, key))
+      continue;
+
+    func (key, value, user_data);
+  }
+}
+
+GSList *
+gst_cv_object_info_map_get_keys_with_sub_key (GstCVObjectInfoMap * self,
+    GstStructure * sub_key)
+{
+  GSList *list = NULL;
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  gst_cv_object_info_map_iter_init (&iter, self);
+  while (gst_cv_object_info_map_iter_next (&iter, &key, &value)) {
+    if (!gst_structure_is_subset (iter.sub_key, key))
+      continue;
+
+    list = g_slist_prepend (list, key);
+  }
+
+  return list;
+}
+
+guint
+gst_cv_object_info_map_get_size (GstCVObjectInfoMap * self)
+{
+  return g_hash_table_size (self);
+}

--- a/gst-libs/gst/cv/object/info/objectinfomap.h
+++ b/gst-libs/gst/cv/object/info/objectinfomap.h
@@ -1,0 +1,94 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef __CV_OBJECT_INFO_MAP_H__
+#define __CV_OBJECT_INFO_MAP_H__
+
+#include <glib.h>
+#include <gst/gst.h>
+#include "objectinfo.h"
+
+G_BEGIN_DECLS
+
+#define GST_CV_OBJECT_INFO_KEY_NAME "cvobjectinfokey"
+
+typedef GHashTable GstCVObjectInfoMap;
+
+struct _GstCVObjectInfoMapIter {
+  GHashTableIter iter;
+  GstStructure *sub_key;
+};
+
+typedef struct _GstCVObjectInfoMapIter GstCVObjectInfoMapIter;
+
+
+typedef void         (*GstCVObjectInfoMapFunc)                     (GstStructure *    key,
+                                                                    GstCVObjectInfo * value,
+                                                                    gpointer          user_data);
+
+gboolean             gst_cv_object_info_map_check_key              (GstStructure * key);
+
+GstCVObjectInfoMap * gst_cv_object_info_map_new                    (void);
+
+void                 gst_cv_object_info_map_destroy                (GstCVObjectInfoMap * self);
+
+GstCVObjectInfoMap * gst_cv_object_info_map_copy                   (GstCVObjectInfoMap * self);
+
+GstCVObjectInfoMap * gst_cv_object_info_map_copy_with_sub_key      (GstCVObjectInfoMap * self,
+                                                                    GstStructure * sub_key);
+
+gboolean             gst_cv_object_info_map_insert                 (GstCVObjectInfoMap * self,
+                                                                    GstStructure *       key,
+                                                                    GstCVObjectInfo *    value);
+
+GstCVObjectInfo *    gst_cv_object_info_map_lookup                 (GstCVObjectInfoMap * self,
+                                                                    const GstStructure * key);
+
+void                 gst_cv_object_info_map_iter_init              (GstCVObjectInfoMapIter * iter,
+                                                                    GstCVObjectInfoMap     * map);
+
+gboolean             gst_cv_object_info_map_iter_next              (GstCVObjectInfoMapIter * iter,
+                                                                    GstStructure **          key,
+                                                                    GstCVObjectInfo **       value);
+
+void                 gst_cv_object_info_map_iter_init_with_sub_key (GstCVObjectInfoMapIter * iter,
+                                                                    GstCVObjectInfoMap *     map,
+                                                                    GstStructure *           sub_key);
+
+gboolean             gst_cv_object_info_map_iter_next_with_sub_key (GstCVObjectInfoMapIter * iter,
+                                                                    GstStructure **          key,
+                                                                    GstCVObjectInfo **       value);
+
+void                 gst_cv_object_info_map_foreach                (GstCVObjectInfoMap *   self,
+                                                                    GstCVObjectInfoMapFunc foreach_func,
+                                                                    gpointer               user_data);
+
+void                 gst_cv_object_info_map_foreach_with_sub_key   (GstCVObjectInfoMap *   self,
+                                                                    GstStructure *         sub_key,
+                                                                    GstCVObjectInfoMapFunc func,
+                                                                    gpointer               user_data);
+
+GSList *             gst_cv_object_info_map_get_keys_with_sub_key  (GstCVObjectInfoMap * self,
+                                                                    GstStructure *       sub_key);
+
+guint                gst_cv_object_info_map_get_size               (GstCVObjectInfoMap * self);
+
+G_END_DECLS
+
+#endif /* __CV_OBJECT_INFO_MAP_H__ */

--- a/gst-libs/gst/cv/object/info/objectinfomapcache.c
+++ b/gst-libs/gst/cv/object/info/objectinfomapcache.c
@@ -1,0 +1,138 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "objectinfomapcache.h"
+
+struct _GstCVObjectInfoMapCache
+{
+  guint max_size;
+  GstStructure *sub_key_filter;
+  GHashTable *cache;
+  GQueue insertion_order_queue;
+};
+
+static gpointer
+gst_cv_object_info_map_cache_key_new (guint64 * key)
+{
+  guint64 *key_ptr = g_slice_new (guint64);
+  *key_ptr = *key;
+  return (gpointer) key_ptr;
+}
+
+static void
+gst_cv_object_info_map_cache_key_free (gpointer k)
+{
+  g_slice_free (guint64, (guint64 *) k);
+}
+
+GstCVObjectInfoMapCache *
+gst_cv_object_info_map_cache_new (guint max_size)
+{
+  GstCVObjectInfoMapCache *cache;
+
+  cache = g_slice_new0 (GstCVObjectInfoMapCache);
+  cache->max_size = max_size;
+  cache->sub_key_filter = NULL;
+  cache->cache = g_hash_table_new_full (g_int64_hash, g_int64_equal,
+      gst_cv_object_info_map_cache_key_free,
+      (GDestroyNotify) gst_cv_object_info_map_destroy);
+
+  return cache;
+}
+
+GstCVObjectInfoMapCache *
+gst_cv_object_info_map_cache_new_with_sub_key (guint max_size,
+    GstStructure * info_map_sub_key_filter)
+{
+  GstCVObjectInfoMapCache *cache;
+
+  g_return_val_if_fail (GST_IS_STRUCTURE (info_map_sub_key_filter) &&
+      gst_cv_object_info_map_check_key (info_map_sub_key_filter), FALSE);
+
+  cache = gst_cv_object_info_map_cache_new (max_size);
+  cache->sub_key_filter = gst_structure_copy (info_map_sub_key_filter);
+
+  return cache;
+}
+
+guint
+gst_cv_object_info_map_cache_get_size (GstCVObjectInfoMapCache * self)
+{
+  return g_hash_table_size (self->cache);
+}
+
+guint
+gst_cv_object_info_map_cache_get_max_size (GstCVObjectInfoMapCache * self)
+{
+  return self->max_size;
+}
+
+GstStructure *
+gst_cv_object_info_map_cache_get_sub_key (GstCVObjectInfoMapCache * self)
+{
+  if (self->sub_key_filter == NULL)
+    return NULL;
+  return gst_structure_copy (self->sub_key_filter);
+}
+
+void
+gst_cv_object_info_map_cache_destroy (GstCVObjectInfoMapCache * self)
+{
+  if (self->sub_key_filter)
+    gst_structure_free (self->sub_key_filter);
+  g_queue_free (&self->insertion_order_queue);
+  g_hash_table_destroy (self->cache);
+}
+
+gboolean
+gst_cv_object_info_map_cache_insert (GstCVObjectInfoMapCache * self,
+    guint64 frame_number, GstCVObjectInfoMap * map)
+{
+  GstCVObjectInfoMap *map_copy;
+  gpointer key;
+
+  if (gst_cv_object_info_map_cache_get_size (self) == self->max_size) {
+    gpointer popped_key;
+
+    /* Remove the least recently inserted inserted item to the cache. */
+    popped_key = g_queue_pop_head (&self->insertion_order_queue);
+    g_assert (g_hash_table_remove (self->cache, popped_key));
+  }
+
+  key = gst_cv_object_info_map_cache_key_new (&frame_number);
+  if (self->sub_key_filter)
+    map_copy =
+        gst_cv_object_info_map_copy_with_sub_key (map, self->sub_key_filter);
+  else
+    map_copy = gst_cv_object_info_map_copy (map);
+  g_queue_push_tail (&self->insertion_order_queue, key);
+
+  return g_hash_table_insert (self->cache, key, map_copy);
+}
+
+GstCVObjectInfo *
+gst_cv_object_info_map_cache_lookup (GstCVObjectInfoMapCache * self,
+    guint64 frame_number)
+{
+  gpointer lookup_result;
+
+  lookup_result = g_hash_table_lookup (self->cache, &frame_number);
+
+  return lookup_result;
+}

--- a/gst-libs/gst/cv/object/info/objectinfomapcache.h
+++ b/gst-libs/gst/cv/object/info/objectinfomapcache.h
@@ -1,0 +1,54 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef __CV_OBJECT_INFO_MAP_CACHE_H__
+#define __CV_OBJECT_INFO_MAP_CACHE_H__
+
+#include <glib.h>
+#include <gst/gst.h>
+#include "objectinfomap.h"
+
+G_BEGIN_DECLS
+
+typedef struct _GstCVObjectInfoMapCache GstCVObjectInfoMapCache;
+
+
+GstCVObjectInfoMapCache * gst_cv_object_info_map_cache_new              (guint max_size);
+
+GstCVObjectInfoMapCache * gst_cv_object_info_map_cache_new_with_sub_key (guint max_size,
+                                                                         GstStructure * info_map_sub_key_filter);
+
+guint                     gst_cv_object_info_map_cache_get_size         (GstCVObjectInfoMapCache * self);
+
+guint                     gst_cv_object_info_map_cache_get_max_size     (GstCVObjectInfoMapCache * self);
+
+GstStructure *            gst_cv_object_info_map_cache_get_sub_key      (GstCVObjectInfoMapCache * self);
+
+void                      gst_cv_object_info_map_cache_destroy          (GstCVObjectInfoMapCache * self);
+
+gboolean                  gst_cv_object_info_map_cache_insert           (GstCVObjectInfoMapCache * self,
+                                                                         guint64 frame_number,
+                                                                         GstCVObjectInfoMap * map);
+
+GstCVObjectInfo *         gst_cv_object_info_map_cache_lookup           (GstCVObjectInfoMapCache * self,
+                                                                         guint64 frame_number);
+
+G_END_DECLS
+
+#endif /* __CV_OBJECT_INFO_MAP_CACHE_H__ */

--- a/gst-libs/gst/cv/object/info/objectinfomapcachemeta.c
+++ b/gst-libs/gst/cv/object/info/objectinfomapcachemeta.c
@@ -1,0 +1,112 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:gstcvobjectinfomapcachemeta
+ * @title: GstCVObjectInfoMapCacheMeta
+ * @short_description: Metadata class for holding ROI info.
+ *
+ * The GstCVObjectInfoMapCacheMeta class contains a #GstCVObjectInfoMap which holds
+ * information about an object (i.e. the ROI, region-of-interest for a given
+ * object).
+ */
+
+#include "objectinfomapcachemeta.h"
+
+GType
+gst_cv_object_info_map_cache_meta_api_get_type (void)
+{
+  static volatile GType type;
+  static const gchar *tags[] = { NULL };
+
+  if (g_once_init_enter (&type)) {
+    GType _type =
+        gst_meta_api_type_register ("GstCVObjectInfoMapCacheMetaAPI", tags);
+    g_once_init_leave (&type, _type);
+  }
+
+  return type;
+}
+
+gboolean
+gst_cv_object_info_map_cache_meta_init (GstMeta * meta, gpointer params,
+    GstBuffer * buffer)
+{
+  return TRUE;
+}
+
+void
+gst_cv_object_info_map_cache_meta_free (GstMeta * meta, GstBuffer * buffer)
+{
+  GstCVObjectInfoMapCacheMeta *self = (GstCVObjectInfoMapCacheMeta *) meta;
+  g_free (self->element_name);
+  gst_cv_object_info_map_cache_destroy (self->object_info_map_cache);
+}
+
+const GstMetaInfo *
+gst_cv_object_info_map_cache_meta_get_info (void)
+{
+  static const GstMetaInfo *cv_object_info_map_cache_meta_info = NULL;
+
+  if (g_once_init_enter (&cv_object_info_map_cache_meta_info)) {
+    const GstMetaInfo *meta =
+        gst_meta_register (GST_CV_OBJECT_INFO_MAP_CACHE_META_API_TYPE,
+        "GstCVObjectInfoMapCacheMeta",
+        sizeof (GstCVObjectInfoMapCacheMeta),
+        gst_cv_object_info_map_cache_meta_init,
+        gst_cv_object_info_map_cache_meta_free,
+        (GstMetaTransformFunction) NULL);
+    g_once_init_leave (&cv_object_info_map_cache_meta_info, meta);
+  }
+  return cv_object_info_map_cache_meta_info;
+}
+
+GstCVObjectInfoMapCache
+    * gst_cv_object_info_map_cache_meta_get_object_info_map_cache
+    (GstCVObjectInfoMapCacheMeta * self) {
+  return self->object_info_map_cache;
+}
+
+/**
+ * gst_buffer_add_cv_object_info_map_cache_meta:
+ * @buffer: (transfer none): #GstBuffer to which info about an object should be
+ * added.
+ *
+ * Attaches a #GstCVObjectInfoMap to a #GstBuffer.
+ *
+ * Returns: A pointer to the added #GstCVObjectInfoMapCacheMeta if successful; %NULL
+ * if unsuccessful.
+ */
+GstCVObjectInfoMapCacheMeta *
+gst_buffer_add_cv_object_info_map_cache_meta (GstBuffer * buffer,
+    guint cache_size, const gchar * element_name)
+{
+  GstCVObjectInfoMapCacheMeta *meta;
+
+  g_return_val_if_fail (GST_IS_BUFFER (buffer), NULL);
+
+  meta =
+      (GstCVObjectInfoMapCacheMeta *) gst_buffer_add_meta (buffer,
+      GST_CV_OBJECT_INFO_MAP_CACHE_META_INFO, NULL);
+
+  meta->element_name = g_strdup (element_name);
+  meta->object_info_map_cache = gst_cv_object_info_map_cache_new (cache_size);
+  return meta;
+}

--- a/gst-libs/gst/cv/object/info/objectinfomapcachemeta.h
+++ b/gst-libs/gst/cv/object/info/objectinfomapcachemeta.h
@@ -1,0 +1,65 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_CV_OBJECT_INFO_MAP_CACHE_META_H__
+#define __GST_CV_OBJECT_INFO_MAP_CACHE_META_H__
+
+#include <gst/gst.h>
+#include <graphene.h>
+#include "objectinfomapcache.h"
+
+G_BEGIN_DECLS
+
+#define GST_CV_OBJECT_INFO_MAP_CACHE_META_API_TYPE (gst_cv_object_info_map_cache_meta_api_get_type())
+#define gst_buffer_get_cv_object_info_map_cache_meta(b) \
+    ((GstCVObjectInfoMapCacheMeta*)gst_buffer_get_meta ((b), GST_CV_OBJECT_INFO_MAP_CACHE_META_API_TYPE))
+#define GST_CV_OBJECT_INFO_MAP_CACHE_META_INFO (gst_cv_object_info_map_cache_meta_get_info())
+
+
+typedef struct _GstCVObjectInfoMapCacheMeta GstCVObjectInfoMapCacheMeta;
+
+struct _GstCVObjectInfoMapCacheMeta {
+  GstMeta meta;
+
+  gchar *element_name;
+  GstCVObjectInfoMapCache *object_info_map_cache;
+};
+
+
+GType                         gst_cv_object_info_map_cache_meta_api_get_type              (void);
+
+gboolean                      gst_cv_object_info_map_cache_meta_init                      (GstMeta   * meta,
+                                                                                           gpointer    params,
+                                                                                           GstBuffer * buffer);
+
+void                          gst_cv_object_info_map_cache_meta_free                      (GstMeta   * meta,
+                                                                                           GstBuffer * buffer);
+
+const GstMetaInfo *           gst_cv_object_info_map_cache_meta_get_info                  (void);
+
+GstCVObjectInfoMapCache *     gst_cv_object_info_map_cache_meta_get_object_info_map_cache (GstCVObjectInfoMapCacheMeta * self);
+
+GstCVObjectInfoMapCacheMeta * gst_buffer_add_cv_object_info_map_cache_meta                (GstBuffer   * buffer,
+                                                                                           guint         cache_size,
+                                                                                           const gchar * element_name);
+
+G_END_DECLS
+
+#endif /* __GST_CV_OBJECT_INFO_MAP_CACHE_META_H__ */

--- a/gst-libs/gst/cv/object/info/objectinfomapmeta.c
+++ b/gst-libs/gst/cv/object/info/objectinfomapmeta.c
@@ -1,0 +1,109 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:gstcvobjectinfomapmeta
+ * @title: GstCVObjectInfoMapMeta
+ * @short_description: Metadata class for holding ROI info.
+ *
+ * The GstCVObjectInfoMapMeta class contains a #GstCVObjectInfoMap which holds
+ * information about an object (i.e. the ROI, region-of-interest for a given
+ * object).
+ */
+
+#include "objectinfomapmeta.h"
+
+GType
+gst_cv_object_info_map_meta_api_get_type (void)
+{
+  static volatile GType type;
+  static const gchar *tags[] = { NULL };
+
+  if (g_once_init_enter (&type)) {
+    GType _type =
+        gst_meta_api_type_register ("GstCVObjectInfoMapMetaAPI", tags);
+    g_once_init_leave (&type, _type);
+  }
+
+  return type;
+}
+
+gboolean
+gst_cv_object_info_map_meta_init (GstMeta * meta, gpointer params,
+    GstBuffer * buffer)
+{
+  return TRUE;
+}
+
+void
+gst_cv_object_info_map_meta_free (GstMeta * meta, GstBuffer * buffer)
+{
+  GstCVObjectInfoMapMeta *self = (GstCVObjectInfoMapMeta *) meta;
+  gst_cv_object_info_map_destroy (self->object_info_map);
+}
+
+const GstMetaInfo *
+gst_cv_object_info_map_meta_get_info (void)
+{
+  static const GstMetaInfo *cv_object_info_map_meta_info = NULL;
+
+  if (g_once_init_enter (&cv_object_info_map_meta_info)) {
+    const GstMetaInfo *meta =
+        gst_meta_register (GST_CV_OBJECT_INFO_MAP_META_API_TYPE,
+        "GstCVObjectInfoMapMeta",
+        sizeof (GstCVObjectInfoMapMeta),
+        gst_cv_object_info_map_meta_init,
+        gst_cv_object_info_map_meta_free,
+        (GstMetaTransformFunction) NULL);
+    g_once_init_leave (&cv_object_info_map_meta_info, meta);
+  }
+  return cv_object_info_map_meta_info;
+}
+
+GstCVObjectInfoMap *gst_cv_object_info_map_meta_get_object_info_map
+    (GstCVObjectInfoMapMeta * self)
+{
+  return self->object_info_map;
+}
+
+/**
+ * gst_buffer_add_cv_object_info_map_meta:
+ * @buffer: (transfer none): #GstBuffer to which info about an object should be
+ * added.
+ *
+ * Attaches a #GstCVObjectInfoMap to a #GstBuffer.
+ *
+ * Returns: A pointer to the added #GstCVObjectInfoMapMeta if successful; %NULL
+ * if unsuccessful.
+ */
+GstCVObjectInfoMapMeta *
+gst_buffer_add_cv_object_info_map_meta (GstBuffer * buffer)
+{
+  GstCVObjectInfoMapMeta *meta;
+
+  g_return_val_if_fail (GST_IS_BUFFER (buffer), NULL);
+
+  meta =
+      (GstCVObjectInfoMapMeta *) gst_buffer_add_meta (buffer,
+      GST_CV_OBJECT_INFO_MAP_META_INFO, NULL);
+
+  meta->object_info_map = gst_cv_object_info_map_new ();
+  return meta;
+}

--- a/gst-libs/gst/cv/object/info/objectinfomapmeta.h
+++ b/gst-libs/gst/cv/object/info/objectinfomapmeta.h
@@ -1,0 +1,62 @@
+/*
+ * GStreamer Plugins CV
+ * Copyright (C) 2019 Cesar Fabian Orccon Chipana <cfoch.fabian@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_CV_OBJECT_INFO_MAP_META_H__
+#define __GST_CV_OBJECT_INFO_MAP_META_H__
+
+#include <gst/gst.h>
+#include <graphene.h>
+#include "objectinfomap.h"
+
+G_BEGIN_DECLS
+
+#define GST_CV_OBJECT_INFO_MAP_META_API_TYPE (gst_cv_object_info_map_meta_api_get_type())
+#define gst_buffer_get_cv_object_info_map_meta(b) \
+    ((GstCVObjectInfoMapMeta*)gst_buffer_get_meta ((b), GST_CV_OBJECT_INFO_MAP_META_API_TYPE))
+#define GST_CV_OBJECT_INFO_MAP_META_INFO (gst_cv_object_info_map_meta_get_info())
+
+
+typedef struct _GstCVObjectInfoMapMeta GstCVObjectInfoMapMeta;
+
+struct _GstCVObjectInfoMapMeta {
+  GstMeta meta;
+
+  GstCVObjectInfoMap *object_info_map;
+};
+
+
+GType                    gst_cv_object_info_map_meta_api_get_type        (void);
+
+gboolean                 gst_cv_object_info_map_meta_init                (GstMeta   * meta,
+                                                                          gpointer    params,
+                                                                          GstBuffer * buffer);
+
+void                     gst_cv_object_info_map_meta_free                (GstMeta   * meta,
+                                                                          GstBuffer * buffer);
+
+const GstMetaInfo *      gst_cv_object_info_map_meta_get_info            (void);
+
+GstCVObjectInfoMap *     gst_cv_object_info_map_meta_get_object_info_map (GstCVObjectInfoMapMeta * self);
+
+GstCVObjectInfoMapMeta * gst_buffer_add_cv_object_info_map_meta          (GstBuffer * buffer);
+
+G_END_DECLS
+
+#endif /* __GST_CV_OBJECT_INFO_MAP_META_H__ */

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ graphene_dep = dependency('graphene-1.0', version : ['>= 1.7.0'],
 
 subdir('gst-libs')
 subdir('ext')
+subdir('tests')
 
 python3 = import('python').find_installation()
 run_command(python3, '-c', 'import shutil; shutil.copy("hooks/pre-commit.hook", ".git/hooks/pre-commit")')

--- a/tests/cv/meson.build
+++ b/tests/cv/meson.build
@@ -1,0 +1,1 @@
+subdir('object')

--- a/tests/cv/object/info/meson.build
+++ b/tests/cv/object/info/meson.build
@@ -1,0 +1,20 @@
+exe = executable('objectinfo',
+  'objectinfo.c',
+  install : false,
+  dependencies : [gstcv_dep]
+)
+test('objectinfo', exe)
+
+exe = executable('objectinfomap',
+  'objectinfomap.c',
+  install : false,
+  dependencies : [gstcv_dep]
+)
+test('objectinfomap', exe)
+
+exe = executable('objectinfomapcache',
+  'objectinfomapcache.c',
+  install : false,
+  dependencies : [gstcv_dep]
+)
+test('objectinfomapcache', exe)

--- a/tests/cv/object/info/objectinfo.c
+++ b/tests/cv/object/info/objectinfo.c
@@ -1,0 +1,151 @@
+#include <gst/cv/object/info/objectinfo.h>
+
+static void
+test_new ()
+{
+  GstCVObjectInfo *info;
+  const GValue *info_value;
+  GValue value = G_VALUE_INIT;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, 100);
+
+  info = gst_cv_object_info_new (&value);
+  info_value = gst_cv_object_info_get_value (info);
+
+  g_assert_false (info_value == &value);
+  g_assert_cmpint (g_value_get_int (info_value), ==, g_value_get_int (&value));
+  g_assert_null (gst_cv_object_info_get_params (info));
+
+  gst_cv_object_info_free (info);
+  g_value_unset (&value);
+}
+
+static void
+test_new_invalid_args ()
+{
+  GstCVObjectInfo *info;
+  GValue uninitialized_value;
+
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*G_IS_VALUE*failed");
+  info = gst_cv_object_info_new (&uninitialized_value);
+  g_assert_null (info);
+}
+
+static void
+test_new_with_params ()
+{
+  GstCVObjectInfo *info;
+  GValue value = G_VALUE_INIT;
+  GstStructure *s;
+  const GValue *info_value;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, 100);
+  s = gst_structure_new_empty ("foo");
+
+  info = gst_cv_object_info_new_with_params (&value, s);
+  info_value = gst_cv_object_info_get_value (info);
+
+  g_assert_false (info_value == &value);
+  g_assert_cmpint (g_value_get_int (info_value), ==, g_value_get_int (&value));
+  g_assert_true (gst_cv_object_info_get_params (info) == s);
+
+  gst_cv_object_info_free (info);
+  g_value_unset (&value);
+}
+
+static void
+test_new_with_params_invalid_args ()
+{
+  GstCVObjectInfo *info;
+  GValue uninitialized_value, good_value = G_VALUE_INIT;
+  GstStructure *good_structure, *bad_structure;
+
+  bad_structure = NULL;
+  good_structure = gst_structure_new_empty ("foo");
+
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*G_IS_VALUE*failed");
+  info = gst_cv_object_info_new_with_params (&uninitialized_value,
+      good_structure);
+  g_assert_null (info);
+
+  gst_structure_free (good_structure);
+
+  g_value_init (&good_value, G_TYPE_INT);
+  g_value_set_int (&good_value, 100);
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*GST_IS_STRUCTURE*failed");
+  info = gst_cv_object_info_new_with_params (&good_value, bad_structure);
+  g_assert_null (info);
+
+  g_value_unset (&good_value);
+}
+
+static void
+test_add_params ()
+{
+  GstCVObjectInfo *info;
+  GValue value = G_VALUE_INIT;
+  GstStructure *st;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, 100);
+  info = gst_cv_object_info_new (&value);
+
+  st = gst_structure_new_empty ("foo");
+  gst_cv_object_info_add_params (info, st);
+  g_assert_true (st == gst_cv_object_info_get_params (info));
+
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*NULL*failed");
+  gst_cv_object_info_add_params (info, st);
+  g_assert_true (st == gst_cv_object_info_get_params (info));
+
+  gst_cv_object_info_free (info);
+  g_value_unset (&value);
+}
+
+static void
+test_copy ()
+{
+  GstCVObjectInfo *info, *copy;
+  GValue value = G_VALUE_INIT;
+  const GValue *src_value, *copy_value;
+  GstStructure *st, *st_copy;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, 100);
+  st = gst_structure_new_empty ("foo");
+  info = gst_cv_object_info_new_with_params (&value, st);
+  copy = gst_cv_object_info_copy (info);
+
+  src_value = gst_cv_object_info_get_value (info);
+  copy_value = gst_cv_object_info_get_value (copy);
+  g_assert_cmpint (G_VALUE_TYPE (src_value), ==, G_VALUE_TYPE (copy_value));
+  g_assert_cmpint (g_value_get_int (src_value), ==,
+      g_value_get_int (copy_value));
+
+  st_copy = gst_cv_object_info_get_params (copy);
+  g_assert_true (gst_structure_is_equal (st, st_copy));
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/cv/object/info/test_info_new", test_new);
+  g_test_add_func ("/cv/object/info/test_info_new_invalid_args",
+      test_new_invalid_args);
+  g_test_add_func ("/cv/object/info/test_info_new_with_params",
+      test_new_with_params);
+  g_test_add_func ("/cv/object/info/test_info_new_with_params_invalid_args",
+      test_new_with_params_invalid_args);
+  g_test_add_func ("/cv/object/info/test_info_add_params", test_add_params);
+  g_test_add_func ("/cv/object/info/test_info_copy", test_copy);
+
+  return g_test_run ();
+}

--- a/tests/cv/object/info/objectinfomap.c
+++ b/tests/cv/object/info/objectinfomap.c
@@ -1,0 +1,180 @@
+#include <gst/cv/object/info/objectinfomap.h>
+
+static GstCVObjectInfo *
+create_object_info (gint internal_value)
+{
+  GstCVObjectInfo *info;
+  GValue value = G_VALUE_INIT;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, internal_value);
+
+  info = gst_cv_object_info_new (&value);
+
+  return info;
+}
+
+static void
+test_insert_invalid_args ()
+{
+  GstCVObjectInfoMap *map;
+  GstStructure *valid_key, *invalid_key;
+  GstCVObjectInfo *valid_value;
+
+  valid_value = create_object_info (100);
+  valid_key =
+      gst_structure_new_from_string ("valid, foo=(int)1, bar=(string)baz;");
+
+  map = gst_cv_object_info_map_new ();
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*G_IS_VALUE*failed");
+  g_assert_false (gst_cv_object_info_map_insert (map, valid_key, NULL));
+
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*assertion*GST_IS_STRUCTURE*failed");
+  g_assert_false (gst_cv_object_info_map_insert (map, NULL, valid_value));
+
+  invalid_key = gst_structure_new_from_string ("invalid, foo=(fraction)1;");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*gst_cv_object_info_map_check_key*");
+  gst_cv_object_info_map_insert (map, invalid_key, valid_value);
+  gst_structure_free (invalid_key);
+
+  invalid_key =
+      gst_structure_new_from_string ("invalid, foo=(date)1994-01-17;");
+  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_CRITICAL,
+      "*gst_cv_object_info_map_check_key*");
+  gst_cv_object_info_map_insert (map, invalid_key, valid_value);
+  gst_structure_free (invalid_key);
+
+  gst_cv_object_info_free (valid_value);
+}
+
+static void
+test_insert_lookup ()
+{
+  GstCVObjectInfoMap *map;
+  GstStructure *key1, *key2, *key3, *key4, *key5;
+  GstCVObjectInfo *val1, *val2, *val3, *val4, *val5;
+
+  key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  val1 = create_object_info (1);
+
+  map = gst_cv_object_info_map_new ();
+  g_assert_true (gst_cv_object_info_map_insert (map, key1, val1));
+  g_assert_true (val1 == gst_cv_object_info_map_lookup (map, key1));
+
+  key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  val2 = create_object_info (2);
+  g_assert_true (gst_cv_object_info_map_insert (map, key2, val2));
+  g_assert_true (val1 == gst_cv_object_info_map_lookup (map, key1));
+  g_assert_true (val2 == gst_cv_object_info_map_lookup (map, key2));
+
+  key3 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)face, element=(string)element1, type=(string)roi;");
+  val3 = create_object_info (3);
+  g_assert_true (gst_cv_object_info_map_insert (map, key3, val3));
+  g_assert_true (val1 == gst_cv_object_info_map_lookup (map, key1));
+  g_assert_true (val2 == gst_cv_object_info_map_lookup (map, key2));
+  g_assert_true (val3 == gst_cv_object_info_map_lookup (map, key3));
+
+  key4 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)face, element=(string)element1, type=(string)roi;");
+  val4 = create_object_info (4);
+  g_assert_true (gst_cv_object_info_map_insert (map, key4, val4));
+  g_assert_true (val1 == gst_cv_object_info_map_lookup (map, key1));
+  g_assert_true (val2 == gst_cv_object_info_map_lookup (map, key2));
+  g_assert_true (val3 == gst_cv_object_info_map_lookup (map, key3));
+  g_assert_true (val4 == gst_cv_object_info_map_lookup (map, key4));
+
+  key5 = gst_structure_new_from_string ("whatever, banana=(string)yellow;");
+  val5 = create_object_info (100);
+  g_assert_true (gst_cv_object_info_map_insert (map, key5, val5));
+  g_assert_true (val1 == gst_cv_object_info_map_lookup (map, key1));
+  g_assert_true (val2 == gst_cv_object_info_map_lookup (map, key2));
+  g_assert_true (val3 == gst_cv_object_info_map_lookup (map, key3));
+  g_assert_true (val4 == gst_cv_object_info_map_lookup (map, key4));
+  g_assert_true (val5 == gst_cv_object_info_map_lookup (map, key5));
+
+  gst_cv_object_info_map_destroy (map);
+}
+
+static void
+test_iter ()
+{
+  GstCVObjectInfoMap *map;
+  GstStructure *subkey;
+  GstStructure *key1, *key2, *key3, *key4, *key5;
+  GstCVObjectInfo *val1, *val2, *val3, *val4, *val5;
+  /* iter vars */
+  GSList *list = NULL;
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key;
+  GstCVObjectInfo *value;
+
+  val1 = create_object_info (1);
+  key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+
+  key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  val2 = create_object_info (2);
+
+  key3 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)face, element=(string)element1, type=(string)roi;");
+  val3 = create_object_info (3);
+
+  key4 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)face, element=(string)element1, type=(string)roi;");
+  val4 = create_object_info (4);
+
+  key5 = gst_structure_new_from_string ("whatever, banana=(string)yellow;");
+  val5 = create_object_info (100);
+
+  map = gst_cv_object_info_map_new ();
+  gst_cv_object_info_map_insert (map, key1, val1);
+  gst_cv_object_info_map_insert (map, key2, val2);
+  gst_cv_object_info_map_insert (map, key3, val3);
+  gst_cv_object_info_map_insert (map, key4, val4);
+  gst_cv_object_info_map_insert (map, key5, val5);
+
+  list = NULL;
+  gst_cv_object_info_map_iter_init (&iter, map);
+  while (gst_cv_object_info_map_iter_next (&iter, &key, &value)) {
+    g_assert_null (g_slist_find (list, key));
+    g_assert_true ((key == key1 && value == val1) ||
+        (key == key2 && value == val2) ||
+        (key == key3 && value == val3) ||
+        (key == key4 && value == val4) || (key == key5 && value == val5));
+  }
+  g_slist_free (list);
+
+  list = NULL;
+  subkey = gst_structure_new_from_string ("whatever, label=(string)face, "
+      "element=(string)element1;");
+  gst_cv_object_info_map_iter_init_with_sub_key (&iter, map, subkey);
+  while (gst_cv_object_info_map_iter_next_with_sub_key (&iter, &key, &value)) {
+    g_assert_null (g_slist_find (list, key));
+    g_assert_true ((key == key3 && value == val3) || (key == key4
+            && value == val4));
+  }
+  gst_structure_free (subkey);
+  g_slist_free (list);
+
+  gst_cv_object_info_map_destroy (map);
+}
+
+int
+main (int argc, char *argv[])
+{
+  gst_init (&argc, &argv);
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/cv/object/info/test_info_map_insert_invalid_args",
+      test_insert_invalid_args);
+  g_test_add_func ("/cv/object/info/test_insert_lookup", test_insert_lookup);
+  g_test_add_func ("/cv/object/info/test_iter", test_iter);
+
+  return g_test_run ();
+}

--- a/tests/cv/object/info/objectinfomapcache.c
+++ b/tests/cv/object/info/objectinfomapcache.c
@@ -1,0 +1,188 @@
+#include <gst/cv/object/info/objectinfomapcache.h>
+
+static GstCVObjectInfo *
+create_object_info (gint internal_value)
+{
+  GstCVObjectInfo *info;
+  GValue value = G_VALUE_INIT;
+
+  g_value_init (&value, G_TYPE_INT);
+  g_value_set_int (&value, internal_value);
+
+  info = gst_cv_object_info_new (&value);
+
+  return info;
+}
+
+
+gboolean
+object_info_map_is_equal (GstCVObjectInfoMap * map1, GstCVObjectInfoMap * map2)
+{
+  GstCVObjectInfoMapIter iter;
+  GstStructure *key1;
+  GstCVObjectInfo *value1, *value2;
+
+  if (gst_cv_object_info_map_get_size (map1) !=
+      gst_cv_object_info_map_get_size (map2))
+    return FALSE;
+
+  gst_cv_object_info_map_iter_init (&iter, map1);
+  while (gst_cv_object_info_map_iter_next (&iter, &key1, &value1)) {
+    const GValue *value1_value, *value2_value;
+
+    value2 = gst_cv_object_info_map_lookup (map2, key1);
+
+    value1_value = gst_cv_object_info_get_value (value1);
+    value2_value = gst_cv_object_info_get_value (value2);
+
+    if (g_value_get_int (value1_value) != g_value_get_int (value2_value))
+      return FALSE;
+  }
+
+  return TRUE;
+}
+
+static void
+test_new ()
+{
+  GstCVObjectInfoMapCache *cache;
+  GstStructure *sub_key;
+
+  cache = gst_cv_object_info_map_cache_new (5);
+  g_assert_cmpint (0, ==, gst_cv_object_info_map_cache_get_size (cache));
+  g_assert_cmpint (5, ==, gst_cv_object_info_map_cache_get_max_size (cache));
+  gst_cv_object_info_map_cache_destroy (cache);
+
+  sub_key = gst_structure_new_from_string ("whatever, label=(string)face, "
+      "element=(string)element1;");
+
+  cache = gst_cv_object_info_map_cache_new_with_sub_key (5, sub_key);
+  g_assert_cmpint (0, ==, gst_cv_object_info_map_cache_get_size (cache));
+  g_assert_cmpint (5, ==, gst_cv_object_info_map_cache_get_max_size (cache));
+  g_assert_true (gst_structure_is_equal (sub_key,
+          gst_cv_object_info_map_cache_get_sub_key (cache)));
+  gst_cv_object_info_map_cache_destroy (cache);
+
+  gst_structure_free (sub_key);
+}
+
+static void
+test_insert ()
+{
+  GstCVObjectInfoMapCache *cache;
+  /* map1 */
+  GstCVObjectInfoMap *map1;
+  GstStructure *map1_key1, *map1_key2;
+  GstCVObjectInfo *map1_val1, *map1_val2;
+  /* map2 */
+  GstCVObjectInfoMap *map2;
+  GstStructure *map2_key1, *map2_key2;
+  GstCVObjectInfo *map2_val1, *map2_val2;
+  /* map3 */
+  GstCVObjectInfoMap *map3;
+  GstStructure *map3_key1, *map3_key2;
+  GstCVObjectInfo *map3_val1, *map3_val2;
+  /* map4 */
+  GstCVObjectInfoMap *map4;
+  GstStructure *map4_key1, *map4_key2;
+  GstCVObjectInfo *map4_val1, *map4_val2;
+
+  cache = gst_cv_object_info_map_cache_new (3);
+
+  /* Insert map at frame 100 */
+  map1 = gst_cv_object_info_map_new ();
+  map1_key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map1_val1 = create_object_info (11);
+  gst_cv_object_info_map_insert (map1, map1_key1, map1_val1);
+
+  map1_key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map1_val2 = create_object_info (12);
+  gst_cv_object_info_map_insert (map1, map1_key2, map1_val2);
+
+  g_assert_true (gst_cv_object_info_map_cache_insert (cache, 100, map1));
+
+  g_assert_true (object_info_map_is_equal (map1, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 100)));
+
+  /* Insert map at frame 101 */
+  map2 = gst_cv_object_info_map_new ();
+  map2_key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map2_val1 = create_object_info (21);
+  gst_cv_object_info_map_insert (map2, map2_key1, map2_val1);
+
+  map2_key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map2_val2 = create_object_info (22);
+  gst_cv_object_info_map_insert (map2, map2_key2, map2_val2);
+
+  g_assert_true (gst_cv_object_info_map_cache_insert (cache, 101, map2));
+
+  g_assert_true (object_info_map_is_equal (map1, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 100)));
+  g_assert_true (object_info_map_is_equal (map2, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 101)));
+
+  /* Insert map at frame 102 */
+  map3 = gst_cv_object_info_map_new ();
+  map3_key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map3_val1 = create_object_info (31);
+  gst_cv_object_info_map_insert (map3, map3_key1, map3_val1);
+
+  map3_key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map3_val2 = create_object_info (32);
+  gst_cv_object_info_map_insert (map3, map3_key2, map3_val2);
+
+  g_assert_true (gst_cv_object_info_map_cache_insert (cache, 102, map3));
+
+  g_assert_true (object_info_map_is_equal (map1, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 100)));
+  g_assert_true (object_info_map_is_equal (map2, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 101)));
+  g_assert_true (object_info_map_is_equal (map3, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 102)));
+
+  /* Insert map at frame 103 */
+  map4 = gst_cv_object_info_map_new ();
+  map4_key1 = gst_structure_new_from_string ("whatever, index=(int)1, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map4_val1 = create_object_info (41);
+  gst_cv_object_info_map_insert (map4, map4_key1, map4_val1);
+
+  map4_key2 = gst_structure_new_from_string ("whatever, index=(int)2, "
+      "label=(string)car, element=(string)element0, type=(string)roi;");
+  map4_val2 = create_object_info (42);
+  gst_cv_object_info_map_insert (map4, map4_key2, map4_val2);
+
+  g_assert_true (gst_cv_object_info_map_cache_insert (cache, 103, map4));
+  // Cache size reached. Map at frame 100 should have been removed internally.
+  g_assert_null (gst_cv_object_info_map_cache_lookup (cache, 100));
+
+  g_assert_true (object_info_map_is_equal (map2, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 101)));
+  g_assert_true (object_info_map_is_equal (map3, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 102)));
+  g_assert_true (object_info_map_is_equal (map4, (GstCVObjectInfoMap *)
+          gst_cv_object_info_map_cache_lookup (cache, 103)));
+
+  gst_cv_object_info_map_destroy (map1);
+  gst_cv_object_info_map_destroy (map2);
+  gst_cv_object_info_map_destroy (map3);
+  gst_cv_object_info_map_destroy (map4);
+  gst_cv_object_info_map_cache_destroy (cache);
+}
+
+int
+main (int argc, char *argv[])
+{
+  gst_init (&argc, &argv);
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/cv/object/info/test_info_map_cache_new", test_new);
+  g_test_add_func ("/cv/object/info/test_info_map_cache_insert", test_insert);
+
+  return g_test_run ();
+}

--- a/tests/cv/object/meson.build
+++ b/tests/cv/object/meson.build
@@ -1,0 +1,1 @@
+subdir('info')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,1 @@
+subdir('cv')


### PR DESCRIPTION
The following structures have been added:

 - objectinfo
   Stores a (generic) value and some params to store extra info.
   For example, to store information about a car, we can use a
   graphene_rect_t (the ROI for the car) and the license plate and
   car color in params.

 - objectinfomap
   A hash table of objectinfo values. The key, a GstStructure, is
   composed by various values.
   For example, some keys can be:
    - label=car,element=car-detector,type=roi,index=1
    - label=car,element=car-detector,type=roi,index=2
    - label=car,element=car-detector,type=roi,index=3
    - ...
    - label=face,element=frontal-face-detector,type=roi,index=1
    - label=face,element=frontal-face-detector,type=roi,index=2
    - ...
    - label=face,element=face-with-mask-detector,type=roi,index=1
    - label=face,element=face-with-mask-detector,type=roi,index=2
    all of them in the same map

   It is a hash map to try to have almost O(1) access.

   The reason to have composed keys is because in this way, elements
   can filter by the subkey (of the key). For example, a car tracker
   would filter by label=car,element=car-detector,type=roi and access
   all the cars with distinct indexes.

 - objectinfocache
   A hash table of objectinfomap values. The key is a number that
   can be a timestamp or a frame number.

   This structure is supposed to cache objectinfomap of past frames.

   The reason to implement this structure is that there are some
   algorithms that need information from the past to predict future
   information, like an object tracker.

Unit tests are implemented. Run with ´ninja test´.

Closes #11