### PR TITLE
hooks: Prevent infinite loop running toolbox inside toolbox

### DIFF
--- a/scripts/helpers/indent-helper.sh
+++ b/scripts/helpers/indent-helper.sh
@@ -71,7 +71,7 @@ if check_uncrustify; then
 fi
 
 if test "x$INDENT" = "x" || test "x$UNCRUSTIFY" = "x"; then
-  if check_toolbox; then
+  if check_toolbox && [ ! -f /run/.toolboxenv ]; then
     echo "Running script in toolbox."
     toolbox run bash -c "$SCRIPT $@"
     exit $?


### PR DESCRIPTION
In newer versions of toolbox, it is possible to run the toolbox command
inside toolbox. This commit makes to run toolbox only if /run/.toolboxenv
does not exist (which means not inside a toolbox container).

Closes #19